### PR TITLE
shift/push on scalar (arrayref) is now forbidden

### DIFF
--- a/lib/MultiDbgp/Debugger.pm
+++ b/lib/MultiDbgp/Debugger.pm
@@ -107,9 +107,9 @@ sub check_and_send_command {
 
 	return if @{ $self->{ command_history } } && 0 < scalar grep { ! defined $_->{ response } } @{ $self->{ command_history } };
 
-	my $command = shift $self->{ command_queue };
+	my $command = shift @{$self->{ command_queue }};
 	my $transaction_id = $self->use_transaction_id();
-	push $self->{ command_history }, {
+	push @{$self->{ command_history }}, {
 		transaction_id => $transaction_id,
 		command => $command,
 		response => undef,
@@ -152,14 +152,14 @@ sub check_and_send_command {
 sub commands {
 	my ( $self, $commands ) = @_;
 
-	push $self->{ command_queue }, $_ for @$commands;
+	push @{$self->{ command_queue }}, $_ for @$commands;
 #	print STDERR "command queue size: ". scalar @{ $self->{ command_queue } } ."\n";
 	$self->check_and_send_command();
 }
 
 sub add_on_error_or_exit_handler {
 	my ( $self, $handler, $context ) = @_;
-	push $self->{ on_error_or_exit_handlers }, [ $handler, $context ];
+	push @{$self->{ on_error_or_exit_handlers }}, [ $handler, $context ];
 }
 
 sub del_on_error_or_exit_handlers {
@@ -170,7 +170,7 @@ sub del_on_error_or_exit_handlers {
 
 sub add_on_message_handler {
 	my ( $self, $handler, $context ) = @_;
-	push $self->{ on_message_handlers }, [ $handler, $context ];
+	push @{$self->{ on_message_handlers }}, [ $handler, $context ];
 }
 
 sub del_on_message_handlers {

--- a/lib/MultiDbgp/Dispatcher/LazySessionSelection.pm
+++ b/lib/MultiDbgp/Dispatcher/LazySessionSelection.pm
@@ -222,7 +222,7 @@ sub start {
 sub get_debugger_client {
 	my ( $self, $handler ) = @_;
 
-	push $self->{ on_new_client }, $handler;
+	push @{$self->{ on_new_client }}, $handler;
 
 	return if $self->{ state } eq 'waiting_client';
 	$self->{ state } = 'waiting_client';
@@ -245,7 +245,7 @@ sub get_debugger_client {
 				$self->{ state } = 'multiplexing';
 				
 				while( @{ $self->{ on_new_client } } ) {
-					my $on_client_handler = shift $self->{ on_new_client };
+					my $on_client_handler = shift @{$self->{ on_new_client }};
 					$on_client_handler->( undef, $client )
 				}
 			}
@@ -254,7 +254,7 @@ sub get_debugger_client {
 
 				$self->{ state } = 'waiting_debugger';
 				while( @{ $self->{ on_new_client } } ) {
-					my $on_client_handler = shift $self->{ on_new_client };
+					my $on_client_handler = shift @{$self->{ on_new_client }};
 					$on_client_handler->( "failed client connection", undef );
 				}
 			}
@@ -266,7 +266,7 @@ sub detach_all_debuggers {
 	my ( $self ) = @_;
 
 	while( @{ $self->{ debuggers } } ) {
-		my $debugger = shift $self->{ debuggers };
+		my $debugger = shift @{$self->{ debuggers }};
 		$debugger->command_detach();
 	}
 }


### PR DESCRIPTION
When trying to run MultiDbgp with recent versions of Perl, two modules
fail with compilation errors, withe these messages:

Experimental shift on scalar is now forbidden at ...
Experimental push on scalar is now forbidden at ...

This commit fixes those errors, and the module now compiles and runs
fine.